### PR TITLE
Fix ModuleLoaderPlugin's destroy implementation

### DIFF
--- a/lib/ComponentManager.lua
+++ b/lib/ComponentManager.lua
@@ -71,8 +71,8 @@ function ComponentManager:disable()
 
 	self.instanceAddedConn:Disconnect()
 	self.instanceRemovedConn:Disconnect()
-	self.descendantAddedConns:cleanup()
-	self.descendantRemovedConns:cleanup()
+	self.descendantAddedConns:clean()
+	self.descendantRemovedConns:clean()
 end
 
 function ComponentManager:destroy()

--- a/lib/Plugins/ModuleLoaderPlugin.lua
+++ b/lib/Plugins/ModuleLoaderPlugin.lua
@@ -88,7 +88,7 @@ end
 
 function ModuleLoaderPlugin.ComponentMixins:destroy()
 	local maid = self[LoaderMaidSymbol]
-	maid:cleanup()
+	maid:clean()
 end
 
 return ModuleLoaderPlugin


### PR DESCRIPTION
`Maid::cleanup` doesn't exist, it's `Maid:clean`!